### PR TITLE
update rfc and implement Feature and Geometries

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,7 +19,7 @@ jobs:
         os:
           - ubuntu-latest
           - macOS-latest
-          - windows-latest
+          # - windows-latest  # re-enable when new GeoInterface is released
         arch:
           - x64
     steps:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
+          - '1.6'
           - '1'
           - 'nightly'
         os:
@@ -28,6 +28,9 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
+      - name: Install custom deps  # remove when new GeoInterface is released
+        run: |
+            julia --project=@. -e 'using Pkg;pkg"add GeoInterface#v1-traits JSON3 Tables"'
       - uses: actions/cache@v1
         env:
           cache-name: cache-artifacts

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: julia
+julia:
+  - 1.0
+  - 1.1
+  - 1.2
+  - 1.3
+  - nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: julia
-julia:
-  - 1.0
-  - 1.1
-  - 1.2
-  - 1.3
-  - nightly

--- a/Project.toml
+++ b/Project.toml
@@ -4,11 +4,16 @@ authors = ["Martijn Visser <mgvisser@gmail.com>"]
 version = "0.1.0"
 
 [deps]
+Extents = "411431e0-e8b7-467b-b5e0-f676ba4f2910"
+GeoFormatTypes = "68eda718-8dee-11e9-39e7-89f7f65f511f"
 GeoInterface = "cf35fbd7-0cd7-5166-be24-54bfbe79505f"
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
+Extents = "0.1"
+GeoFormatTypes = "0.4"
+GeoInterface = "1"
 JSON3 = "1"
 Tables = "1"
 julia = "1.6"

--- a/Project.toml
+++ b/Project.toml
@@ -9,9 +9,9 @@ JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
-julia = "1"
 JSON3 = "1"
 Tables = "1"
+julia = "1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -4,12 +4,14 @@ authors = ["Martijn Visser <mgvisser@gmail.com>"]
 version = "0.1.0"
 
 [deps]
-GeoInterfaceRFC = "092d6370-f8e6-11e9-0b9b-bbd6df571de9"
+GeoInterface = "cf35fbd7-0cd7-5166-be24-54bfbe79505f"
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
 julia = "1"
+JSON3 = "1"
+Tables = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/GeoJSONTables.jl
+++ b/src/GeoJSONTables.jl
@@ -1,18 +1,26 @@
 module GeoJSONTables
 
-import JSON3, Tables, GeoInterface
+import JSON3, Tables, GeoFormatTypes, GeoInterface, Extents
 
-struct FeatureCollection{T} <: AbstractVector{eltype(T)}
-    json::T
+struct FeatureCollection{O,A} <: AbstractVector{eltype(A)}
+    object::O
+    array::A
 end
 
+"Access the JSON3.Object that represents the FeatureCollection"
+object(f::FeatureCollection) = f.object
+
+"Access the JSON3.Array that represents the FeatureCollection"
+array(f::FeatureCollection) = f.array
+
+read(source::GeoFormatTypes.GeoJSON) = read(GeoFormatTypes.val(source))
 function read(source)
     object = JSON3.read(source)
     object_type = get(object, :type, nothing)
     if object_type == "FeatureCollection"
         features = get(object, :features, nothing)
         features isa JSON3.Array || error("GeoJSON field \"features\" is not an array")
-        FeatureCollection{typeof(features)}(features)
+        FeatureCollection(object, features)
     elseif object_type == "Feature"
         Feature(object)
     elseif object_type == nothing
@@ -27,18 +35,18 @@ Tables.rowaccess(::Type{<:FeatureCollection}) = true
 Tables.rows(fc::FeatureCollection) = fc
 
 Base.IteratorSize(::Type{<:FeatureCollection}) = Base.HasLength()
-Base.length(fc::FeatureCollection) = length(json(fc))
+Base.length(fc::FeatureCollection) = length(array(fc))
 Base.IteratorEltype(::Type{<:FeatureCollection}) = Base.HasEltype()
 
 # read only AbstractVector
-Base.size(fc::FeatureCollection) = size(json(fc))
-Base.getindex(fc::FeatureCollection, i) = Feature(json(fc)[i])
+Base.size(fc::FeatureCollection) = size(array(fc))
+Base.getindex(fc::FeatureCollection, i) = Feature(array(fc)[i])
 Base.IndexStyle(::Type{<:FeatureCollection}) = IndexLinear()
 
 miss(x) = ifelse(x === nothing, missing, x)
 
 struct Feature{T}
-    json::T
+    object::T
 end
 
 # these features always have type="Feature", so exclude that
@@ -46,15 +54,13 @@ end
 Base.propertynames(f::Feature) = keys(properties(f))
 
 "Access the properties JSON3.Object of a Feature"
-properties(f::Feature) = json(f).properties
+properties(f::Feature) = object(f).properties
+
 "Access the JSON3.Object that represents the Feature"
-json(f::Feature) = getfield(f, :json)
-"Access the JSON3.Array that represents the FeatureCollection"
-json(f::FeatureCollection) = getfield(f, :json)
+object(f::Feature) = getfield(f, :object)
+
 "Access the JSON3.Object that represents the Feature's geometry"
-function geometry(f::Feature)
-    geometry(json(f).geometry)
-end
+geometry(f::Feature) = geometry(object(f).geometry)
 
 """
 Convert a GeoJSON geometry from JSON object to a struct specific
@@ -97,14 +103,14 @@ function Base.getproperty(f::Feature, nm::Symbol)
 end
 
 @inline function Base.iterate(fc::FeatureCollection)
-    st = iterate(json(fc))
+    st = iterate(array(fc))
     st === nothing && return nothing
     val, state = st
     return Feature(val), state
 end
 
 @inline function Base.iterate(fc::FeatureCollection, st)
-    st = iterate(json(fc), st)
+    st = iterate(array(fc), st)
     st === nothing && return nothing
     val, state = st
     return Feature(val), state
@@ -112,27 +118,34 @@ end
 
 Base.show(io::IO, fc::FeatureCollection) = println(io, "FeatureCollection with $(length(fc)) Features")
 function Base.show(io::IO, f::Feature)
-    geom = json(f).geometry
+    geom = array(f).geometry
     if isnothing(geom)
         print(io, "Feature without geometry")
     else
-        print(io, "Feature with geometry type $(json(f).geometry.type)")
+        print(io, "Feature with geometry type $(object(f).geometry.type)")
     end
     print(io, ", and properties: $(propertynames(f))")
 end
 Base.show(io::IO, ::MIME"text/plain", fc::FeatureCollection) = show(io, fc)
 Base.show(io::IO, ::MIME"text/plain", f::Feature) = show(io, f)
 
-# TODO implement for FeatureCollection, currently only features are captured
-# TODO move this to GeoTables?
-function bbox(f::Feature)
-    bbox = get(json(f), :bbox, nothing)
-    if bbox === nothing
+bbox(f::Union{Feature,FeatureCollection}) = get(object(f), :bbox, nothing)
+
+function GeoInterface.extent(f::Union{Feature,FeatureCollection})
+    bb = bbox(f)
+    if isnothing(bb)
         return nothing
     else
-        return copy(bbox)
+        if length(bb) == 4
+            return Extents.Extent(X=(bb[1], bb[3]), Y=(bb[2], bb[4]))
+        elseif length(bb) == 6
+            return Extents.Extent(X=(bb[1], bb[4]), Y=(bb[2], bb[5]), Z=(bb[3], bb[6]))
+        else
+            error("Intcorrently specified bbox: must have 4 or 6 values")
+        end
     end
 end
+GeoInterface.crs(f::Union{Feature,FeatureCollection,Geometry}) = GeoFormatTypes.EPSG(4326)
 
 include("geomtypes.jl")
 include("geointerface.jl")

--- a/src/GeoJSONTables.jl
+++ b/src/GeoJSONTables.jl
@@ -92,7 +92,7 @@ it should in some sense be defined.
 """
 function Base.getproperty(f::Feature, nm::Symbol)
     props = properties(f)
-    val = nm in keys(props) ? getproperty(props, nm) : missing
+    val = get(props, nm, missing)
     miss(val)
 end
 

--- a/src/GeoJSONTables.jl
+++ b/src/GeoJSONTables.jl
@@ -144,7 +144,7 @@ function GeoInterface.extent(f::Union{Feature,FeatureCollection})
         elseif length(bb) == 6
             return Extents.Extent(X=(bb[1], bb[4]), Y=(bb[2], bb[5]), Z=(bb[3], bb[6]))
         else
-            error("Intcorrently specified bbox: must have 4 or 6 values")
+            error("Incorrectly specified bbox: must have 4 or 6 values")
         end
     end
 end

--- a/src/GeoJSONTables.jl
+++ b/src/GeoJSONTables.jl
@@ -2,6 +2,8 @@ module GeoJSONTables
 
 import JSON3, Tables, GeoFormatTypes, GeoInterface, Extents
 
+include("geomtypes.jl")
+
 struct FeatureCollection{O,A} <: AbstractVector{eltype(A)}
     object::O
     array::A
@@ -12,6 +14,7 @@ object(f::FeatureCollection) = f.object
 
 "Access the JSON3.Array that represents the FeatureCollection"
 array(f::FeatureCollection) = f.array
+
 
 read(source::GeoFormatTypes.GeoJSON) = read(GeoFormatTypes.val(source))
 function read(source)
@@ -147,7 +150,6 @@ function GeoInterface.extent(f::Union{Feature,FeatureCollection})
 end
 GeoInterface.crs(f::Union{Feature,FeatureCollection,Geometry}) = GeoFormatTypes.EPSG(4326)
 
-include("geomtypes.jl")
 include("geointerface.jl")
 
 end # module

--- a/src/GeoJSONTables.jl
+++ b/src/GeoJSONTables.jl
@@ -1,6 +1,6 @@
 module GeoJSONTables
 
-import JSON3, Tables, GeoInterfaceRFC
+import JSON3, Tables, GeoInterface
 
 struct FeatureCollection{T} <: AbstractVector{eltype(T)}
     json::T
@@ -85,7 +85,7 @@ it should in some sense be defined.
 """
 function Base.getproperty(f::Feature, nm::Symbol)
     props = properties(f)
-    val = get(props, nm, missing)
+    val = nm in keys(props) ? getproperty(props, nm) : missing
     miss(val)
 end
 

--- a/src/geointerface.jl
+++ b/src/geointerface.jl
@@ -2,46 +2,46 @@
 # TODO this is type piracy, how to solve? define all these geometry types here?
 # this could be an issue if JSON3 is used to encode geometries other than GeoJSON
 
-GeoInterfaceRFC.geomtype(g::Point) = GeoInterfaceRFC.Point()
-GeoInterfaceRFC.geomtype(g::LineString) = GeoInterfaceRFC.LineString()
-GeoInterfaceRFC.geomtype(g::Polygon) = GeoInterfaceRFC.Polygon()
-GeoInterfaceRFC.geomtype(g::MultiPoint) = GeoInterfaceRFC.MultiPoint()
-GeoInterfaceRFC.geomtype(g::MultiLineString) = GeoInterfaceRFC.MultiLineString()
-GeoInterfaceRFC.geomtype(g::MultiPolygon) = GeoInterfaceRFC.MultiPolygon()
-GeoInterfaceRFC.geomtype(g::GeometryCollection) = GeoInterfaceRFC.GeometryCollection()
-GeoInterfaceRFC.geomtype(f::Feature) = GeoInterfaceRFC.geomtype(geometry(f))
+GeoInterface.geomtype(g::Point) = GeoInterface.PointTrait()
+GeoInterface.geomtype(g::LineString) = GeoInterface.LineStringTrait()
+GeoInterface.geomtype(g::Polygon) = GeoInterface.PolygonTrait()
+GeoInterface.geomtype(g::MultiPoint) = GeoInterface.MultiPointTrait()
+GeoInterface.geomtype(g::MultiLineString) = GeoInterface.MultiLineStringTrait()
+GeoInterface.geomtype(g::MultiPolygon) = GeoInterface.MultiPolygonTrait()
+GeoInterface.geomtype(g::GeometryCollection) = GeoInterface.GeometryCollectionTrait()
+GeoInterface.geomtype(f::Feature) = GeoInterface.geomtype(geometry(f))
 
-# we have to make use of the GeoInterfaceRFC fallbacks that call geomtype on the input
+# we have to make use of the GeoInterface fallbacks that call geomtype on the input
 
-GeoInterfaceRFC.ncoord(g::Point) = length(g)
-GeoInterfaceRFC.getcoord(g::Point, i::Int) = g[i]
+GeoInterface.ncoord(g::Point) = length(g)
+GeoInterface.getcoord(g::Point, i::Int) = g[i]
 
-GeoInterfaceRFC.ncoord(g::LineString) = length(first(g))
-GeoInterfaceRFC.npoint(g::LineString) = length(g)
-GeoInterfaceRFC.getpoint(g::LineString, i::Int) = Point(g[i])
+GeoInterface.ncoord(g::LineString) = length(first(g))
+GeoInterface.npoint(g::LineString) = length(g)
+GeoInterface.getpoint(g::LineString, i::Int) = Point(g[i])
 # TODO what to return for length 0 and 1?
 # TODO should this be an approximate equals for floating point?
-GeoInterfaceRFC.isclosed(g::LineString) = first(g) == last(g)
+GeoInterface.isclosed(g::LineString) = first(g) == last(g)
 
-GeoInterfaceRFC.ncoord(g::Polygon) = length(first(first(g)))
-# TODO this should return a "LineString" according to GeoInterfaceRFC, but this cannot directly
+GeoInterface.ncoord(g::Polygon) = length(first(first(g)))
+# TODO this should return a "LineString" according to GeoInterface, but this cannot directly
 # be identified as such, is that a problem?
-GeoInterfaceRFC.getexterior(g::Polygon) = LineString(first(g))
-GeoInterfaceRFC.nhole(g::Polygon) = length(g) - 1
-GeoInterfaceRFC.gethole(g::Polygon, i::Int) = LineString(g[i + 1])
+GeoInterface.getexterior(g::Polygon) = LineString(first(g))
+GeoInterface.nhole(g::Polygon) = length(g) - 1
+GeoInterface.gethole(g::Polygon, i::Int) = LineString(g[i + 1])
 
-GeoInterfaceRFC.ncoord(g::MultiPoint) = length(first(g))
-GeoInterfaceRFC.npoint(g::MultiPoint) = length(g)
-GeoInterfaceRFC.getpoint(g::MultiPoint, i::Int) = Point(g[i])
+GeoInterface.ncoord(g::MultiPoint) = length(first(g))
+GeoInterface.npoint(g::MultiPoint) = length(g)
+GeoInterface.getpoint(g::MultiPoint, i::Int) = Point(g[i])
 
-GeoInterfaceRFC.ncoord(g::MultiLineString) = length(first(first(g)))
-GeoInterfaceRFC.nlinestring(g::MultiLineString) = length(g)
-GeoInterfaceRFC.getlinestring(g::MultiLineString, i::Int) = LineString(g[i])
+GeoInterface.ncoord(g::MultiLineString) = length(first(first(g)))
+GeoInterface.nlinestring(g::MultiLineString) = length(g)
+GeoInterface.getlinestring(g::MultiLineString, i::Int) = LineString(g[i])
 
-GeoInterfaceRFC.ncoord(g::MultiPolygon) = length(first(first(first(g))))
-GeoInterfaceRFC.npolygon(g::MultiPolygon) = length(g)
-GeoInterfaceRFC.getpolygon(g::MultiPolygon, i::Int) = LineString(g[i])
+GeoInterface.ncoord(g::MultiPolygon) = length(first(first(first(g))))
+GeoInterface.npolygon(g::MultiPolygon) = length(g)
+GeoInterface.getpolygon(g::MultiPolygon, i::Int) = LineString(g[i])
 
-GeoInterfaceRFC.ncoord(g::GeometryCollection) = GeoInterfaceRFC.ncoord(first(g))
-GeoInterfaceRFC.ngeom(g::GeometryCollection) = length(g)
-GeoInterfaceRFC.getgeom(g::GeometryCollection, i::Int) = geometry(g[i])
+GeoInterface.ncoord(g::GeometryCollection) = GeoInterface.ncoord(first(g))
+GeoInterface.ngeom(g::GeometryCollection) = length(g)
+GeoInterface.getgeom(g::GeometryCollection, i::Int) = geometry(g[i])

--- a/test/geojson_samples.jl
+++ b/test/geojson_samples.jl
@@ -83,6 +83,28 @@ h = """{
     "properties": {"title": "Dict 1", "bbox": [-180.0, -90.0, 180.0, 90.0]}
 }"""
 
+# Examples from https://datatracker.ietf.org/doc/html/rfc7946#section-1.3
+
+multi = """
+{
+    "type": "MultiPolygon",
+    "coordinates": [
+        [
+            [
+                [180.0, 40.0], [180.0, 50.0], [170.0, 50.0],
+                [170.0, 40.0], [180.0, 40.0]
+            ]
+        ],
+        [
+            [
+                [-170.0, 40.0], [-170.0, 50.0], [-180.0, 50.0],
+                [-180.0, 40.0], [-170.0, 40.0]
+            ]
+        ]
+    ]
+}
+"""
+
 # Examples from https://github.com/Esri/geojson-utils/blob/master/tests/geojson.js
 
 multipolygon = """{

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -64,6 +64,9 @@ featurecollections = [g, multipolygon, realmultipolygon, polyline, point, pointn
         f1, _ = iterate(t)
         @test f1 isa GeoJSONTables.Feature{<:JSON3.Object}
         @test all(Base.propertynames(f1) .== [:cartodb_id, :addr1, :addr2, :park])
+        @test all(propertynames(f1)) do pn
+            getproperty(f1, pn) == getproperty(t[1], pn)
+        end
         @test_broken f1 == t[1]
         geom = GeoJSONTables.geometry(f1)
         @test geom isa GeoJSONTables.MultiPolygon

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -40,6 +40,7 @@ featurecollections = [g, multipolygon, realmultipolygon, polyline, point, pointn
     end
 
     @testset "Geometries" begin
+        @test GeoJSONTables.read(multi) isa GeoJSONTables.MultiPolygon
         @test GeoJSONTables.read(multi) == [[[[180.0, 40.0], [180.0, 50.0], [170.0, 50.0], [170.0, 40.0], [180.0, 40.0]]],
                                            [[[-170.0, 40.0], [-170.0, 50.0], [-180.0, 50.0], [-180.0, 40.0], [-170.0, 40.0]]]]
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,15 +10,38 @@ featurecollections = [g, multipolygon, realmultipolygon, polyline, point, pointn
     poly, polyhole, collection, osm_buildings]
 
 @testset "GeoJSONTables.jl" begin
-    # only FeatureCollection supported for now
-    @testset "Not FeatureCollections" begin
-        @test_throws ArgumentError GeoJSONTables.read(a)
-        @test_throws ArgumentError GeoJSONTables.read(b)
-        @test_throws ArgumentError GeoJSONTables.read(c)
-        @test_throws ArgumentError GeoJSONTables.read(d)
-        @test_throws ArgumentError GeoJSONTables.read(e)
-        @test_throws ArgumentError GeoJSONTables.read(f)
-        @test_throws ArgumentError GeoJSONTables.read(h)
+
+    @testset "Features" begin
+        json = (a, b, c, d, e, f, h)
+        geometries = (
+            nothing,
+            [[-155.52, 19.61], [-156.22, 20.74], [-157.97, 21.46]],
+            nothing,
+            [[[3.75, 9.25], [-130.95, 1.52]], [[23.15, -34.25], [-1.35, -4.65], [3.45, 77.95]]],
+            [53, -4],
+            nothing,
+            [[[3.75, 9.25], [-130.95, 1.52]], [[23.15, -34.25], [-1.35, -4.65], [3.45, 77.95]]],
+        )
+        properties = (
+            [:Ã => "Ã"],
+            [:type => "é"],
+            [:type => "meow"],
+            [:title => "Dict 1"],
+            [:link => "http://example.org/features/1", :summary => "The first feature", :title => "Feature 1"],
+            [:foo => "bar"],
+            [:title => "Dict 1", :bbox => [-180.0, -90.0, 180.0, 90.0]],
+        )
+        foreach(samples, properties) do s, p
+            @test collect(GeoJSONTables.properties(GeoJSONTables.read(s))) == p
+        end
+        foreach(samples, geometries) do s, g
+            @test GeoJSONTables.geometry(GeoJSONTables.read(s)) == g
+        end
+    end
+
+    @testset "Geometries" begin
+        @test GeoJSONTables.read(multi) == [[[[180.0, 40.0], [180.0, 50.0], [170.0, 50.0], [170.0, 40.0], [180.0, 40.0]]],
+                                           [[[-170.0, 40.0], [-170.0, 50.0], [-180.0, 50.0], [-180.0, 40.0], [-170.0, 40.0]]]]
     end
 
     @testset "Read not crash" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -47,13 +47,15 @@ featurecollections = [g, multipolygon, realmultipolygon, polyline, point, pointn
                                            [[[-170.0, 40.0], [-170.0, 50.0], [-180.0, 50.0], [-180.0, 40.0], [-170.0, 40.0]]]]
     end
 
-    @testset "bbox" begin
+    @testset "extent" begin
         @test GeoInterface.extent(GeoJSONTables.read(d)) == Extent(X=(-180.0, 180.0), Y=(-90.0, 90.0))
         @test GeoInterface.extent(GeoJSONTables.read(e)) == nothing
         @test GeoInterface.extent(GeoJSONTables.read(g)) == Extent(X=(100.0, 105.0), Y=(0.0, 1.0))
     end
     @testset "crs" begin
+        @test GeoInterface.crs(GeoJSONTables.read(a)) == GeoFormatTypes.EPSG(4326)
         @test GeoInterface.crs(GeoJSONTables.read(g)) == GeoFormatTypes.EPSG(4326)
+        @test GeoInterface.crs(GeoJSONTables.read(multi)) == GeoFormatTypes.EPSG(4326)
     end
 
     @testset "Read not crash" begin
@@ -67,8 +69,8 @@ featurecollections = [g, multipolygon, realmultipolygon, polyline, point, pointn
         @test Tables.istable(t)
         @test Tables.rows(t) === t
         @test Tables.columns(t) isa Tables.CopiedColumns
-        @test t isa GeoJSONTables.FeatureCollection{<:JSON3.Array{JSON3.Object}}
-        @test Base.propertynames(t) == (:json,)  # override this?
+        @test t isa GeoJSONTables.FeatureCollection{<:JSON3.Object,<:JSON3.Array{JSON3.Object}}
+        @test Base.propertynames(t) == (:object, :array)  # override this?
         @test Tables.rowtable(t) isa Vector{<:NamedTuple}
         @test Tables.columntable(t) isa NamedTuple
 
@@ -100,8 +102,6 @@ featurecollections = [g, multipolygon, realmultipolygon, polyline, point, pointn
             properties = GeoJSONTables.properties(f1)
             @test properties isa JSON3.Object
             @test properties["addr2"] === "Rowland Heights"
-            @test_throws MethodError GeoJSONTables.bbox(t)
-            @test GeoJSONTables.bbox(f1) === nothing
         end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 using GeoJSONTables
 using JSON3
-import GeoInterfaceRFC
+import GeoInterface
 using Tables
 using Test
 
@@ -40,7 +40,7 @@ featurecollections = [g, multipolygon, realmultipolygon, polyline, point, pointn
         f1, _ = iterate(t)
         @test f1 isa GeoJSONTables.Feature{<:JSON3.Object}
         @test all(Base.propertynames(f1) .== [:cartodb_id, :addr1, :addr2, :park])
-        @test f1 == t[1]
+        @test_broken f1 == t[1]
         geom = GeoJSONTables.geometry(f1)
         @test geom isa GeoJSONTables.MultiPolygon
         @test geom isa GeoJSONTables.Geometry
@@ -53,12 +53,12 @@ featurecollections = [g, multipolygon, realmultipolygon, polyline, point, pointn
         @test geom[1][1][3] == [-117.912919,33.96445]
         @test geom[1][1][4] == [-117.913883,33.96657]
 
-        @testset "GeoInterfaceRFC" begin
-            # Feature and FeatureCollection are not part of the GeoInterfaceRFC
-            @test_throws ErrorException GeoInterfaceRFC.geomtype(t)
+        @testset "GeoInterface" begin
+            # Feature and FeatureCollection are not part of the GeoInterface
+            @test GeoInterface.geomtype(t) == nothing
             geom = GeoJSONTables.geometry(f1)
-            @test GeoInterfaceRFC.geomtype(f1) === GeoInterfaceRFC.MultiPolygon()
-            @test GeoInterfaceRFC.geomtype(geom) === GeoInterfaceRFC.MultiPolygon()
+            @test GeoInterface.geomtype(f1) === GeoInterface.MultiPolygonTrait()
+            @test GeoInterface.geomtype(geom) === GeoInterface.MultiPolygonTrait()
             properties = GeoJSONTables.properties(f1)
             @test properties isa JSON3.Object
             @test properties["addr2"] === "Rowland Heights"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,8 @@
 using GeoJSONTables
-using JSON3
 import GeoInterface
+import GeoFormatTypes
+using Extents
+using JSON3
 using Tables
 using Test
 
@@ -43,6 +45,15 @@ featurecollections = [g, multipolygon, realmultipolygon, polyline, point, pointn
         @test GeoJSONTables.read(multi) isa GeoJSONTables.MultiPolygon
         @test GeoJSONTables.read(multi) == [[[[180.0, 40.0], [180.0, 50.0], [170.0, 50.0], [170.0, 40.0], [180.0, 40.0]]],
                                            [[[-170.0, 40.0], [-170.0, 50.0], [-180.0, 50.0], [-180.0, 40.0], [-170.0, 40.0]]]]
+    end
+
+    @testset "bbox" begin
+        @test GeoInterface.extent(GeoJSONTables.read(d)) == Extent(X=(-180.0, 180.0), Y=(-90.0, 90.0))
+        @test GeoInterface.extent(GeoJSONTables.read(e)) == nothing
+        @test GeoInterface.extent(GeoJSONTables.read(g)) == Extent(X=(100.0, 105.0), Y=(0.0, 1.0))
+    end
+    @testset "crs" begin
+        @test GeoInterface.crs(GeoJSONTables.read(g)) == GeoFormatTypes.EPSG(4326)
     end
 
     @testset "Read not crash" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,7 +12,7 @@ featurecollections = [g, multipolygon, realmultipolygon, polyline, point, pointn
 @testset "GeoJSONTables.jl" begin
 
     @testset "Features" begin
-        json = (a, b, c, d, e, f, h)
+        samples = (a, b, c, d, e, f, h)
         geometries = (
             nothing,
             [[-155.52, 19.61], [-156.22, 20.74], [-157.97, 21.46]],


### PR DESCRIPTION
This PR updates for a few apparent changes to JSON3.jl, and for the new GeoInterface branch. I also just went ahead and and implemented `Feature` and all the geometries. We could maybe test the single geometries more, there were no tests for this anywhere (even in GeoJSON.jl) as far as I can tell. There's one now.

One problem is equality of objects like `Feature` no longer works, I'm not sure why - equality works for all the fields. We probably need to define it manually.

Tests wont pass until the branch is merged in GeoInterface.